### PR TITLE
Fix failing tests with some versions of libmagic

### DIFF
--- a/t/constructor-params.t
+++ b/t/constructor-params.t
@@ -24,15 +24,17 @@ use File::LibMagic;
     my $info = File::LibMagic->new( follow_symlinks => 1 )
         ->info_from_filename($link_file);
 
-    is_deeply(
-        $info, {
-            description        => 'PDF document, version 1.4',
-            mime_type          => 'application/pdf',
-            encoding           => 'binary',
-            mime_with_encoding => 'application/pdf; charset=binary',
-        },
-        'got expected info for symlink to PDF'
-    );
+    if(is(ref $info, 'HASH', 'is hash')) {
+        is_deeply([ sort keys %$info ],
+                  [qw[ description encoding mime_type mime_with_encoding ]],
+                  'keys');
+        is($info->{description}, 'PDF document, version 1.4', 'description');
+        is($info->{mime_type}, 'application/pdf', 'mime type');
+        like($info->{encoding}, qr/^(?:binary|unknown)$/, 'encoding');
+        like($info->{mime_with_encoding},
+             qr%^application/pdf; charset=(?:binary|unknown)$%,
+             'mime with charset');
+    }
 }
 
 {

--- a/t/oo-api.t
+++ b/t/oo-api.t
@@ -13,17 +13,17 @@ use File::LibMagic;
         'foo.foo' => [
             'ASCII text',
             'text/plain',
-            'us-ascii',
+            qr/us-ascii/,
         ],
         'foo.c' => [
             [ 'ASCII C program text', 'C source, ASCII text' ],
             'text/x-c',
-            'us-ascii',
+            qr/us-ascii/,
         ],
         'tiny.pdf' => [
             'PDF document, version 1.4',
             'application/pdf',
-            'binary',
+            qr/binary|unknown/,
         ],
     );
 
@@ -224,15 +224,15 @@ sub _test_info {
         'mime_type',
     );
 
-    is(
+    like(
         $info->{encoding},
-        $encoding,
+        qr/^(?:$encoding)$/,
         'encoding'
     );
 
-    is(
+    like(
         $info->{mime_with_encoding},
-        "$mime; charset=$encoding",
+        qr/^$mime; charset=(?:$encoding)$/,
         'mime_with_encoding'
     );
 }


### PR DESCRIPTION
On my Linux box (openSUSE 13.1, MAGIC_VERSION 515), the tests were failing in the same way as on OpenBSD at [CPANTesters](http://www.cpantesters.org/distro/F/File-LibMagic.html?oncpan=1&distmat=1&version=1.12&grade=3): for PDFs, the library returned `unknown` charset rather than `binary`. This fix changes the tests to accept both possibilities.