### PR TITLE
Change how include dirs are passed to ExtUtils::CBuilder

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -104,7 +104,7 @@ sub _defines {
 
     my $ac = Config::AutoConf->new(
         extra_link_flags   => [ _libs() ],
-        extra_include_dirs => [ _includes() ],
+        extra_include_dirs => [ @includes ],
     );
 
     _check_libmagic($ac);


### PR DESCRIPTION
Needs a single dir as a string, or an arrayref of strings.

Fixes this installation issue, when `libmagic` is already installed via `brew`:
```
perl Makefile.PL --lib /usr/local/lib --include /usr/local/include
Checking for magic.h... no

  This module requires the libmagic.so library and magic.h header. See
  INSTALL.md for more details on installing these.
```